### PR TITLE
Add Alembic config and refine dashboard layout

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,23 +1,26 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="d-flex justify-content-between align-items-center mb-3">
-  <h1 class="h4">Projects</h1>
+<div class="d-flex flex-wrap justify-content-between align-items-center mb-4 gap-2">
+  <h1 class="h4 mb-0">Projects</h1>
   <a class="btn btn-primary" href="{{ url_for('main.project_new') }}"><i class="bi bi-plus"></i> Create Project</a>
 </div>
-<div class="row g-3">
+<div class="row g-4">
   {% for p in projects %}
-  <div class="col-md-6 col-lg-4">
-    <div class="card h-100">
-      <div class="card-body">
-        <h5 class="card-title"><a href="{{ url_for('main.project_detail', id=p.id) }}">{{ p.title }}</a></h5>
-        <div class="text-muted small mb-2">{{ p.customer or '—' }} • Rev {{ p.revision or '—' }} • {{ p.units }}</div>
-        <p class="card-text">{{ (p.notes or '')[:160] }}{% if p.notes and p.notes|length > 160 %}…{% endif %}</p>
+  <div class="col-sm-6 col-lg-4">
+    <div class="card h-100 shadow-sm">
+      <div class="card-body d-flex flex-column">
+        <h5 class="card-title"><a href="{{ url_for('main.project_detail', id=p.id) }}" class="text-decoration-none">{{ p.title }}</a></h5>
+        <div class="text-muted small mb-3">{{ p.customer or '—' }} • Rev {{ p.revision or '—' }} • {{ p.units }}</div>
+        <p class="card-text mb-4">{{ (p.notes or '')[:160] }}{% if p.notes and p.notes|length > 160 %}…{% endif %}</p>
+        <div class="mt-auto">
+          <a class="btn btn-sm btn-outline-primary" href="{{ url_for('main.project_detail', id=p.id) }}">View</a>
+        </div>
       </div>
     </div>
   </div>
   {% else %}
   <div class="col-12">
-    <div class="alert alert-info">No projects yet. Create one to get started.</div>
+    <div class="alert alert-info text-center p-5">No projects yet. Create one to get started.</div>
   </div>
   {% endfor %}
 </div>

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s


### PR DESCRIPTION
## Summary
- add Alembic configuration files to support migrations
- refine dashboard template for better spacing and responsiveness

## Testing
- `PYTHONPATH=. pytest -q` *(fails: Popped wrong app context / LookupError)*

------
https://chatgpt.com/codex/tasks/task_b_68aef9ebd1748321b45e081f89b12f8a