### PR TITLE
Switch to uv for installation and fix migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@ A single-user, local-only Flask web app to organize GD&T requirements against dr
 ## Quickstart
 
 ```bash
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+# Install uv (https://astral.sh/uv) if not already installed
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Create a virtual environment and install dependencies
+uv venv
+uv pip install -r requirements.txt
 
 # Initialize database (SQLite by default)
-flask db upgrade
-flask seed
+uv run flask db upgrade
+uv run flask seed
 
 # Run (binds to 127.0.0.1)
-flask run
+uv run flask run
 ```
 
 Open http://127.0.0.1:5000/
@@ -56,7 +60,7 @@ Inside the app, open **Help → User Guide** (top-right) for a step-by-step work
 ## Tests
 
 ```bash
-pytest -q
+uv run pytest -q
 ```
 
 Tests cover:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -23,7 +23,12 @@ def create_app():
 
     # Init extensions
     db.init_app(app)
-    migrate.init_app(app, db, render_as_batch=True)  # render_as_batch: smooth SQLite schema changes
+    migrate.init_app(
+        app,
+        db,
+        render_as_batch=True,
+        directory=os.path.abspath(os.path.join(app.root_path, "..", "migrations")),
+    )  # render_as_batch: smooth SQLite schema changes
     csrf.init_app(app)
 
     # Bind host warning

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s: %(message)s
+datefmt = %H:%M:%S

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -36,3 +36,8 @@ def run_migrations_online():
         )
         with context.begin_transaction():
             context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,9 +1,9 @@
 import json
-from app import db, create_app
+from app import db
 from app.models import Project, Drawing, Requirement, Annotation
 
 def test_annotation_hit_polygon(client):
-    app = create_app()
+    app = client.application
     with app.app_context():
         p = Project(title='T', units='mm')
         db.session.add(p); db.session.commit()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,9 +1,9 @@
-from app import db, create_app
+from app import db
 from app.models import Project, Requirement
 from decimal import Decimal
 
 def test_export_csv_row_count(client):
-    app = create_app()
+    app = client.application
     with app.app_context():
         p = Project(title='T', units='mm')
         db.session.add(p); db.session.commit()

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -4,8 +4,7 @@ from decimal import Decimal
 from app.utils import compute_insights
 
 def test_insights_flags_legacy_and_bonus(client):
-    from app import create_app
-    app = create_app()
+    app = client.application
     with app.app_context():
         p = Project(title='T', units='mm')
         db.session.add(p); db.session.commit()


### PR DESCRIPTION
## Summary
- update README to install and run the app using `uv`
- configure migrations to point to the repository's `migrations` directory and add an Alembic config
- adjust tests to reuse the fixture's Flask app so migrations apply cleanly

## Testing
- `uv run python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68be42faf7bc8321bfff0ff953ce3bb9